### PR TITLE
Add simple CI to run cargo test

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,20 +9,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: actions/setup-rust@v1
-        with:
-          rust-version: stable
-
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Run Tests
         run: cargo test --release


### PR DESCRIPTION
Very basic CI pipeline - if we run into issues with testing against the chain we can switch `cargo test` for `cargo check` until we get that sorted.

This uses the github runners (which come with rust installed).  If things are too slow or we need a better box we could switch to `core-build-runner` - but we would need to explicitly allow this repo in the runner settings.