### PR TITLE
Fixes following merge of #16 and #17

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,7 +1,7 @@
 //! Simple CLI for testing the API Key Service
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
-use entropy_api_key_service_client::{ApiKeyServiceClient, OuttieServerInfo};
+use entropy_api_key_service_client::ApiKeyServiceClient;
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Body, Method, Request, Url,
@@ -65,10 +65,8 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|_| anyhow!("x25519 public key must be 32 bytes"))?;
 
     let client = ApiKeyServiceClient::new(
-        OuttieServerInfo {
-            x25519_public_key,
-            endpoint: args.service_url.into(),
-        },
+        args.service_url,
+        x25519_public_key,
         handle_mnemonic(args.mnemonic)?,
     );
 

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -4,12 +4,8 @@ mod test_server;
 use crate::{
     app,
     app_state::{AppState, Configuration},
-    attestation::get_pck,
 };
 use entropy_api_key_service_client::ApiKeyServiceClient;
-use entropy_client::chain_api::entropy::runtime_types::{
-    bounded_collections::bounded_vec::BoundedVec, pallet_outtie::module::OuttieServerInfo,
-};
 use rand_core::OsRng;
 use sp_core::{sr25519, Pair};
 use sp_keyring::Sr25519Keyring;
@@ -43,13 +39,8 @@ pub async fn setup_client() -> AppState {
 /// Returns a client for the test server
 pub fn make_test_client(app_state: &AppState, keyring: &Sr25519Keyring) -> ApiKeyServiceClient {
     ApiKeyServiceClient::new(
-        OuttieServerInfo {
-            endpoint: b"http://127.0.0.1:3001".to_vec(),
-            x25519_public_key: app_state.x25519_public_key(),
-            provisioning_certification_key: BoundedVec(
-                get_pck(app_state.subxt_account_id()).unwrap().to_vec(),
-            ),
-        },
+        "http://127.0.0.1:3001".to_string(),
+        app_state.x25519_public_key(),
         keyring.pair(),
     )
 }


### PR DESCRIPTION
I merged https://github.com/entropyxyz/api_key_tdx/pull/16 and https://github.com/entropyxyz/api_key_tdx/pull/17 a bit hastily and missed somethings that need fixing.  I assumed the client library can compile as it is a dev dependency of the server - but actually `main.rs` on the client will not compile without this fix.