### PR TITLE
Use master tag and not latest for pulling entropy docker image in CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Check production mode compiles
         run: cargo check -F production
 
-      - name: Get entropy binary from latest release
+      - name: Get entropy binary from release with `master` tag
         run: |
-          docker pull entropyxyz/entropy:latest
-          docker create --name extract-entropy-binary entropyxyz/entropy:latest
+          docker pull entropyxyz/entropy:master
+          docker create --name extract-entropy-binary entropyxyz/entropy:master
           docker cp extract-entropy-binary:/usr/local/bin/entropy ./entropy
           docker container remove extract-entropy-binary
 


### PR DESCRIPTION
Closes https://github.com/entropyxyz/api_key_tdx/issues/33

Im still not totally sure this is the best approach to testing this - but i think this is better than using `latest`. 