### PR TITLE
Use url crate more

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -88,11 +88,11 @@ impl ApiKeyServiceClient {
     pub async fn deploy_api_key(
         &self,
         api_key: String,
-        api_url_base: String,
+        api_url: String,
     ) -> Result<(), ClientError> {
         let user_api_key_info = DeployApiKeyInfo {
             api_key,
-            api_url_base,
+            api_url,
             timestamp: get_current_timestamp()?,
         };
 
@@ -116,7 +116,6 @@ impl ApiKeyServiceClient {
     pub async fn make_request(
         &self,
         request: reqwest::Request,
-        api_url_extra: String,
     ) -> Result<reqwest::Response, ClientError> {
         let request_body = match request.body() {
             Some(body) => String::from_utf8(body.as_bytes().unwrap_or_default().to_vec())?,
@@ -125,14 +124,13 @@ impl ApiKeyServiceClient {
         let send_api_key_message = SendApiKeyMessage {
             request_body,
             http_verb: request.method().as_str().to_lowercase().to_string(),
-            api_url_base: request
+            api_url: request
                 .url()
                 .as_str()
                 .to_string()
                 .strip_suffix("/")
                 .unwrap_or(request.url().as_str())
                 .to_string(),
-            api_url_extra,
             timestamp: get_current_timestamp()?,
         };
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -7,7 +7,7 @@ pub struct DeployApiKeyInfo {
     /// The secret API key to be deployed
     pub api_key: String,
     /// URL of the service to use it with
-    pub api_url_base: String,
+    pub api_url: String,
     /// Current unix time in seconds
     pub timestamp: u64,
 }
@@ -19,10 +19,8 @@ pub struct SendApiKeyMessage {
     pub request_body: String,
     /// The HTTP verb to use
     pub http_verb: String,
-    /// The URL base for the HTTP request ex:(http://127.0.0.1:3002")
-    pub api_url_base: String,
-    /// The extra url info after the base url
-    pub api_url_extra: String,
+    /// The URL for the HTTP request
+    pub api_url: String,
     /// Current unix time in seconds
     pub timestamp: u64,
 }

--- a/src/api_keys/api.rs
+++ b/src/api_keys/api.rs
@@ -55,10 +55,7 @@ pub async fn make_request(
         .api_url
         .replace("xxxREPLACE_MExxx", &api_key_info);
     let response = match user_make_request_info.http_verb.as_str() {
-        "get" => {
-            let url = url.replace("xxxREPLACE_MExxx", &api_key_info);
-            Ok(client.get(url).send().await?)
-        }
+        "get" => Ok(client.get(url).send().await?),
         "post" => {
             let result = client
                 .post(url)

--- a/src/api_keys/api.rs
+++ b/src/api_keys/api.rs
@@ -52,17 +52,17 @@ pub async fn make_request(
         .unwrap();
 
     let client = reqwest::Client::new();
-
+    let url = user_make_request_info
+        .api_url
+        .replace("xxxREPLACE_MExxx", &api_key_info);
     let response = match user_make_request_info.http_verb.as_str() {
         "get" => {
-            let url = user_make_request_info
-                .api_url
-                .replace("xxxREPLACE_MExxx", &api_key_info);
+            let url = url.replace("xxxREPLACE_MExxx", &api_key_info);
             Ok(client.get(url).send().await?)
         }
         "post" => {
             let result = client
-                .post(user_make_request_info.api_url)
+                .post(url)
                 .header("Content-Type", "application/json")
                 .header("Authorization", format!("Bearer {}", &api_key_info))
                 .body(user_make_request_info.request_body)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,7 +53,7 @@ pub enum Err {
     UnknownContext,
     #[error("Url parse error: {0}")]
     UrlParse(#[from] url::ParseError),
-    #[error("Url host error")]
+    #[error("Unable to get hostname from given URL")]
     UrlHost,
     #[error("No api key for user url")]
     UrlEmpty,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,12 @@ pub enum Err {
     AttestationRequest(#[from] entropy_client::errors::AttestationRequestError),
     #[error("Invalid or unknown context value given in query string")]
     UnknownContext,
+    #[error("Url parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+    #[error("Url host error")]
+    UrlHost,
+    #[error("No api key for user url")]
+    UrlEmpty,
     #[cfg(feature = "production")]
     #[error("Quote parse: {0}")]
     QuoteParse(#[from] tdx_quote::QuoteParseError),


### PR DESCRIPTION
Closes #30 

uses url::parse more and removes api url base and extra, just gets the host from the url and uses that. As well moves xxxReplace higher up in the call