### PR TITLE
Expose the placeholder string in the client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
  "configfs-tsm",
  "entropy-api-key-service-client",
  "entropy-api-key-service-shared",
- "entropy-client 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
+ "entropy-client",
+ "entropy-protocol",
+ "entropy-shared",
  "entropy-testing-utils",
  "hex",
  "rand 0.8.5",
@@ -1930,8 +1930,8 @@ dependencies = [
  "anyhow",
  "clap",
  "entropy-api-key-service-shared",
- "entropy-client 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
+ "entropy-client",
+ "entropy-protocol",
  "hex",
  "rand 0.8.5",
  "reqwest",
@@ -1953,34 +1953,13 @@ dependencies = [
 [[package]]
 name = "entropy-client"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
-dependencies = [
- "anyhow",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
- "futures",
- "num",
- "rand 0.8.5",
- "serde",
- "sha3",
- "sp-core",
- "subxt",
- "subxt-core",
- "tdx-quote",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "entropy-client"
-version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees#dc1a3267773d55320ea61199fa9a844c8b7093bf"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "blake2",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
+ "entropy-protocol",
+ "entropy-shared",
  "futures",
  "hex",
  "k256",
@@ -2006,11 +1985,11 @@ dependencies = [
 [[package]]
 name = "entropy-kvdb"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "bincode",
  "chacha20poly1305 0.9.1",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
+ "entropy-protocol",
  "hex",
  "rand 0.8.5",
  "rpassword",
@@ -2051,49 +2030,13 @@ dependencies = [
 [[package]]
 name = "entropy-protocol"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "async-trait",
  "axum",
  "bincode",
  "blake2",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
- "futures",
- "getrandom 0.2.16",
- "hex",
- "hpke-rs",
- "hpke-rs-crypto",
- "hpke-rs-rust-crypto",
- "k256",
- "manul",
- "num",
- "rand_core 0.6.4",
- "serde",
- "serde-persistent-deserializer",
- "serde_json",
- "snow",
- "sp-core",
- "subxt",
- "synedrion",
- "thiserror 2.0.12",
- "tokio",
- "tokio-tungstenite 0.27.0",
- "tracing",
- "tracing-subscriber",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "entropy-protocol"
-version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees#dc1a3267773d55320ea61199fa9a844c8b7093bf"
-dependencies = [
- "async-trait",
- "axum",
- "bincode",
- "blake2",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees)",
+ "entropy-shared",
  "futures",
  "getrandom 0.2.16",
  "hex",
@@ -2123,28 +2066,7 @@ dependencies = [
 [[package]]
 name = "entropy-shared"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
-dependencies = [
- "blake2",
- "hex-literal",
- "lazy_static",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "serde_derive",
- "sp-core",
- "sp-runtime",
- "sp-std",
- "strum 0.27.1",
- "strum_macros 0.27.1",
- "subxt",
- "tdx-quote",
-]
-
-[[package]]
-name = "entropy-shared"
-version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=peg%2Fstore-full-tdx-quote-for-trees#dc1a3267773d55320ea61199fa9a844c8b7093bf"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "blake2",
  "hex-literal",
@@ -2165,12 +2087,12 @@ dependencies = [
 [[package]]
 name = "entropy-testing-utils"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "axum",
  "entropy-kvdb",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
+ "entropy-protocol",
+ "entropy-shared",
  "entropy-tss",
  "hex",
  "hex-literal",
@@ -2194,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "entropy-tss"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/entropyxyz/entropy-core?branch=master#ea0c54e14285e93cd400196eff7ab76701ed5816"
+source = "git+https://github.com/entropyxyz/entropy-core?branch=master#0bc5f2aae57adcb630b1ccc625f0c3e9e43df815"
 dependencies = [
  "anyhow",
  "axum",
@@ -2206,11 +2128,11 @@ dependencies = [
  "blake2",
  "bytes",
  "clap",
- "entropy-client 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
+ "entropy-client",
  "entropy-kvdb",
  "entropy-programs-runtime",
- "entropy-protocol 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
- "entropy-shared 0.4.0-rc.1 (git+https://github.com/entropyxyz/entropy-core?branch=master)",
+ "entropy-protocol",
+ "entropy-shared",
  "futures",
  "hex",
  "hkdf",
@@ -7100,7 +7022,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log 0.2.0",
  "tracing-serde",
  "tracing-subscriber",
  "url",
@@ -8092,7 +8014,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -17,6 +17,8 @@ use sp_core::{sr25519, Pair};
 use std::time::{SystemTime, UNIX_EPOCH};
 use subxt::{backend::legacy::LegacyRpcMethods, utils::AccountId32, OnlineClient};
 
+pub use entropy_api_key_service_shared::API_KEY_PLACEHOLDER;
+
 /// Client for API key service
 pub struct ApiKeyServiceClient {
     /// Socket address or hostname of the api key service instance to use

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,9 @@
 //! Shared types used by the API Key Service server and client
 use serde::{Deserialize, Serialize};
 
+/// The placeholder which will be replaced with your API key if given in request headers or body
+pub const API_KEY_PLACEHOLDER: &str = "xxxREPLACE_MExxx";
+
 /// Request payload for the `/deploy-api-key` HTTP route
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct DeployApiKeyInfo {

--- a/src/api_keys/api.rs
+++ b/src/api_keys/api.rs
@@ -1,7 +1,8 @@
 use crate::{
-    DeleteApiKeyInfo, DeployApiKeyInfo, SendApiKeyMessage, app_state::AppState, errors::Err,
+    app_state::AppState, errors::Err, DeleteApiKeyInfo, DeployApiKeyInfo, SendApiKeyMessage,
 };
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{extract::State, http::StatusCode, Json};
+use entropy_api_key_service_shared::API_KEY_PLACEHOLDER;
 use entropy_protocol::sign_and_encrypt::EncryptedSignedMessage;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -78,12 +79,12 @@ pub async fn make_request(
     let client = reqwest::Client::new();
     let url = user_make_request_info
         .api_url
-        .replace("xxxREPLACE_MExxx", &api_key_info);
+        .replace(API_KEY_PLACEHOLDER, &api_key_info);
 
     let mut headers = HeaderMap::new();
     for (key, value) in &user_make_request_info.http_headers {
-        let first = key.replace("xxxREPLACE_MExxx", &api_key_info);
-        let second = value.replace("xxxREPLACE_MExxx", &api_key_info);
+        let first = key.replace(API_KEY_PLACEHOLDER, &api_key_info);
+        let second = value.replace(API_KEY_PLACEHOLDER, &api_key_info);
 
         let header_name = HeaderName::from_bytes(first.as_bytes())?;
         let header_value = HeaderValue::from_str(&second)?;


### PR DESCRIPTION
This is one of the things i noticed when trying to use this for [this example](https://github.com/entropyxyz/llm_api_key_provider).

Its nice to expose the api key placeholder string as a constant for the client to use.